### PR TITLE
Fix bug in jQuery calls

### DIFF
--- a/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
+++ b/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
@@ -1,9 +1,5 @@
-if (!$) {
-    $ = django.jQuery;
-};
-
-$(document).ready(function () {
-  $('#changelist-filter select').on(
+django.jQuery(document).ready(function () {
+  django.jQuery('#changelist-filter select').on(
       'change',
       function (e, choice) {
           var val = $(e.target).val() || '';


### PR DESCRIPTION
The existing code results an error for me in Safari:
```
TypeError: $ is not a function. (In '$('#changelist-filter select')', '$' is undefined)
```

I am relatively confident that this will fix it.