### PR TITLE
Make sure django.jQuery is defined

### DIFF
--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -27,6 +27,7 @@ class AutocompleteFilter(admin.SimpleListFilter):
 
     class Media:
         js = (
+            'admin/js/jquery.init.js',
             'django-admin-autocomplete-filter/js/autocomplete_filter_qs.js',
         )
         css = {


### PR DESCRIPTION
* Fixes #21 
* Fixes #16

### Description
This fixes the problem of `django.jQuery` not being properly defined.

The problem is due to some [changes in Django 2.2](https://docs.djangoproject.com/en/2.2/releases/2.2/#merging-of-form-media-assets) considering Media asset merging. 

I am not completely sure this is the correct fix, because I have little to no experience with `Media` classes. However, I have tested it and it does work.