### PR TITLE
Use django.jQuery instead of dollar sign

### DIFF
--- a/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
+++ b/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
@@ -2,7 +2,7 @@ django.jQuery(document).ready(function () {
   django.jQuery('#changelist-filter select').on(
       'change',
       function (e, choice) {
-          var val = $(e.target).val() || '';
+          var val = django.jQuery(e.target).val() || '';
           var class_name = this.className;
           var param = this.name;
           if (class_name.includes('admin-autocomplete'))


### PR DESCRIPTION
### Description
This replaces the remaining `$` with `django.jQuery`. As is done in #15 

This fixes a `$ is not defined` error that occurs sometimes.