### PR TITLE
fix packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,14 @@ from setuptools import find_packages, setup
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
 
-# allow setup.py to be run from any path
-os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
-
 setup(
     name='django-admin-autocomplete-filter',
     version='0.3',
     packages=find_packages(),
     include_package_data=True,
-    license='GNU Lesser General Public License v3 (LGPLv3)',  # example license
     description='A simple Django app to render list filters in django admin using autocomplete widget',
-    long_description='text/markdown',
+    long_description=README,
+    long_description_content_type='text/markdown',
     url='https://github.com/farhan0581/django-admin-autocomplete-filter',
     author='Farhan Khan',
     author_email='farhan0581@gmail.com',
@@ -25,7 +22,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.0',  # replace "X.Y" as appropriate
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',  # example license
+        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
- long description fix for https://github.com/farhan0581/django-admin-autocomplete-filter/commit/199d4550e4ab6731afa5f300759169aee15121cd#r34188170
- licence parameter is redundant when a licence classifier exists
- changing directory is not a common practice; setup scripts should always be run from their parent directory