### PR TITLE
Allow related field to be used in filter

### DIFF
--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -23,6 +23,7 @@ class AutocompleteFilter(admin.SimpleListFilter):
     is_placeholder_title = False
     widget_attrs = {}
     rel_model = None
+    parameter_name = None
     form_field = forms.ModelChoiceField
 
     class Media:
@@ -37,7 +38,9 @@ class AutocompleteFilter(admin.SimpleListFilter):
         }
 
     def __init__(self, request, params, model, model_admin):
-        self.parameter_name = '{}__{}__exact'.format(self.field_name, self.field_pk)
+        if self.parameter_name is None:
+            self.parameter_name = '{}__{}__exact'.format(self.field_name,
+                                                         self.field_pk)
         super().__init__(request, params, model, model_admin)
 
         if self.rel_model:


### PR DESCRIPTION
This PR can solve: #27  , #11 

This change allow filtering on related field like artiste__record_label, with a Record Label model.
I added parameter_name in attribute, so we can set his value before, and it seems enough to allow the filter on related field.

Example:
Filter order line with the user that is present on the order
```python
class OrderUserFilter(CustomAutocompleteFilter):
    title = 'User'
    field_name = 'user'
    rel_model = Order
    parameter_name = 'order__user'

class OrderLineAdmin(admin.ModelAdmin):
    list_filter = (
        OrderUserFilter,
    )
```