### PR TITLE
adding the ability to override the class AutocompleteSelect

### DIFF
--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -28,6 +28,7 @@ class AutocompleteFilter(admin.SimpleListFilter):
     rel_model = None
     parameter_name = None
     form_field = forms.ModelChoiceField
+    form_widget_class = AutocompleteSelect
 
     class Media:
         js = (
@@ -52,7 +53,7 @@ class AutocompleteFilter(admin.SimpleListFilter):
 
         remote_field = model._meta.get_field(self.field_name).remote_field
 
-        widget = AutocompleteSelect(remote_field,
+        widget = self.form_widget_class(remote_field,
                                     model_admin.admin_site,
                                     custom_url=self.get_autocomplete_url(request, model_admin),)
         form_field = self.get_form_field()


### PR DESCRIPTION
For or some reason, I need to overload the class AutocompleteSelect.
In the current implementation, I have to overload the entire __init__ method.
With the patch I suggested, it will be much easier to do