### PR TITLE
Avoided failures when invalid URL parameters are encountered.

### DIFF
--- a/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
+++ b/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
@@ -63,6 +63,7 @@ function search_to_hash() {
 function hash_to_search(h) {
     var search = String("?");
     for (var k in h) {
+      if (k === '') { continue; } // ignore invalid inputs, e.g. '?&=value'
       for (var i = 0; i < h[k].length; i++) {
         search += search == "?" ? "" : "&";
         search += encodeURIComponent(k) + "=" + encodeURIComponent(h[k][i]);


### PR DESCRIPTION
I encountered a situation where another package added an ampersand directly after the question mark in the GET URL parameters (e.g. `path/to/page/?&a=b`). This lead to this package detecting a key with a name of `""` and a value of `undefined`, which caused problems. This change is intended to avoid such problems.