### PR TITLE
fix bug

### DIFF
--- a/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
+++ b/admin_auto_filters/static/django-admin-autocomplete-filter/js/autocomplete_filter_qs.js
@@ -50,8 +50,8 @@ function search_to_hash() {
     for (var i = 0; i < q.length; i++) {
       var key_val = q[i].split('=');
       // replace '+' (alt space) char explicitly since decode does not
-      var hkey = decodeURIComponent(key_val[0]).replace(/\+/g,' ');
-      var hval = decodeURIComponent(key_val[1]).replace(/\+/g,' ');
+      var hkey = decodeURIComponent(key_val[0].replace(/\+/g,' '));
+      var hval = decodeURIComponent(key_val[1].replace(/\+/g,' '));
       if (h[hkey] == undefined) {
         h[hkey] = [];
       }


### PR DESCRIPTION
At first, querystring is `created_lt=2021-04-13+00%3A00%3A00%2B08%3A00`. After I select a option from autocomplete filter, the querystring convert to `created_ lt=2021-04-13%2000%3A00%3A00%2B08%3A00&fiter=1`. The real param created_lt should be `2021-04-13 00:00:00+08:00`. So must call replace first.