### PR TITLE
Dependent filters

### DIFF
--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -3,25 +3,31 @@ from django import forms
 from django.contrib import admin
 from django.db.models.fields.related import ForeignObjectRel
 from django.db.models.constants import LOOKUP_SEP  # this is '__'
-from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor, ManyToManyDescriptor
+from django.db.models.fields.related_descriptors import (
+    ReverseManyToOneDescriptor,
+    ManyToManyDescriptor,
+)
 from django.forms.widgets import Media, MEDIA_TYPES, media_property
 from django.shortcuts import reverse
 from django import VERSION as DJANGO_VERSION
 
+
 class AutocompleteSelect(Base):
-    def __init__(self, rel, admin_site, attrs=None, choices=(), using=None, custom_url=None):
+    def __init__(
+        self, rel, admin_site, attrs=None, choices=(), using=None, custom_url=None
+    ):
         self.custom_url = custom_url
         super().__init__(rel, admin_site, attrs, choices, using)
-    
+
     def get_url(self):
         return self.custom_url if self.custom_url else super().get_url()
 
 
 class AutocompleteFilter(admin.SimpleListFilter):
-    template = 'django-admin-autocomplete-filter/autocomplete-filter.html'
-    title = ''
-    field_name = ''
-    field_pk = 'pk'
+    template = "django-admin-autocomplete-filter/autocomplete-filter.html"
+    title = ""
+    field_name = ""
+    field_pk = "pk"
     use_pk_exact = True
     is_placeholder_title = False
     widget_attrs = {}
@@ -31,20 +37,18 @@ class AutocompleteFilter(admin.SimpleListFilter):
 
     class Media:
         js = (
-            'admin/js/jquery.init.js',
-            'django-admin-autocomplete-filter/js/autocomplete_filter_qs.js',
+            "admin/js/jquery.init.js",
+            "django-admin-autocomplete-filter/js/autocomplete_filter_qs.js",
         )
         css = {
-            'screen': (
-                'django-admin-autocomplete-filter/css/autocomplete-fix.css',
-            ),
+            "screen": ("django-admin-autocomplete-filter/css/autocomplete-fix.css",),
         }
 
     def __init__(self, request, params, model, model_admin):
         if self.parameter_name is None:
             self.parameter_name = self.field_name
             if self.use_pk_exact:
-                self.parameter_name += '__{}__exact'.format(self.field_pk)
+                self.parameter_name += "__{}__exact".format(self.field_pk)
         super().__init__(request, params, model, model_admin)
 
         if self.rel_model:
@@ -55,9 +59,11 @@ class AutocompleteFilter(admin.SimpleListFilter):
         else:
             remote_field = model._meta.get_field(self.field_name).remote_field
 
-        widget = AutocompleteSelect(remote_field,
-                                    model_admin.admin_site,
-                                    custom_url=self.get_autocomplete_url(request, model_admin),)
+        widget = AutocompleteSelect(
+            remote_field,
+            model_admin.admin_site,
+            custom_url=self.get_autocomplete_url(request, model_admin),
+        )
         form_field = self.get_form_field()
         field = form_field(
             queryset=self.get_queryset_for_field(model, self.field_name),
@@ -68,14 +74,14 @@ class AutocompleteFilter(admin.SimpleListFilter):
         self._add_media(model_admin, widget)
 
         attrs = self.widget_attrs.copy()
-        attrs['id'] = 'id-%s-dal-filter' % self.parameter_name
+        attrs["id"] = "id-%s-dal-filter" % self.parameter_name
         if self.is_placeholder_title:
             # Upper case letter P as dirty hack for bypass django2 widget force placeholder value as empty string ("")
-            attrs['data-Placeholder'] = self.title
+            attrs["data-Placeholder"] = self.title
         self.rendered_widget = field.widget.render(
             name=self.parameter_name,
-            value=self.used_parameters.get(self.parameter_name, ''),
-            attrs=attrs
+            value=self.used_parameters.get(self.parameter_name, ""),
+            attrs=attrs,
         )
 
     @staticmethod
@@ -85,9 +91,15 @@ class AutocompleteFilter(admin.SimpleListFilter):
         except AttributeError:
             field_desc = model._meta.get_field(name)
         if isinstance(field_desc, ManyToManyDescriptor):
-            related_model = field_desc.rel.related_model if field_desc.reverse else field_desc.rel.model
+            related_model = (
+                field_desc.rel.related_model
+                if field_desc.reverse
+                else field_desc.rel.model
+            )
         elif isinstance(field_desc, ReverseManyToOneDescriptor):
-            related_model = field_desc.rel.related_model  # look at field_desc.related_manager_cls()?
+            related_model = (
+                field_desc.rel.related_model
+            )  # look at field_desc.related_manager_cls()?
         elif isinstance(field_desc, ForeignObjectRel):
             # includes ManyToOneRel, ManyToManyRel
             # also includes OneToOneRel - not sure how this would be used
@@ -103,15 +115,19 @@ class AutocompleteFilter(admin.SimpleListFilter):
         return self.form_field
 
     def _add_media(self, model_admin, widget):
-
-        if not hasattr(model_admin, 'Media'):
-            model_admin.__class__.Media = type('Media', (object,), dict())
+        if not hasattr(model_admin, "Media"):
+            model_admin.__class__.Media = type("Media", (object,), dict())
             model_admin.__class__.media = media_property(model_admin.__class__)
 
         def _get_media(obj):
-            return Media(media=getattr(obj, 'Media', None))
+            return Media(media=getattr(obj, "Media", None))
 
-        media = _get_media(model_admin) + widget.media + _get_media(AutocompleteFilter) + _get_media(self)
+        media = (
+            _get_media(model_admin)
+            + widget.media
+            + _get_media(AutocompleteFilter)
+            + _get_media(self)
+        )
 
         for name in MEDIA_TYPES:
             setattr(model_admin.Media, name, getattr(media, "_" + name))
@@ -127,12 +143,12 @@ class AutocompleteFilter(admin.SimpleListFilter):
             return queryset.filter(**{self.parameter_name: self.value()})
         else:
             return queryset
-    
+
     def get_autocomplete_url(self, request, model_admin):
-        '''
-            Hook to specify your custom view for autocomplete,
-            instead of default django admin's search_results.
-        '''
+        """
+        Hook to specify your custom view for autocomplete,
+        instead of default django admin's search_results.
+        """
         return None
 
 
@@ -141,6 +157,7 @@ def generate_choice_field(label_item):
     Create a ModelChoiceField variant with a modified label_from_instance.
     Note that label_item can be a callable, or a model field, or a model callable.
     """
+
     class LabelledModelChoiceField(forms.ModelChoiceField):
         def label_from_instance(self, obj):
             if callable(label_item):
@@ -152,8 +169,9 @@ def generate_choice_field(label_item):
                 else:
                     value = attr
             else:
-                raise ValueError('Invalid label_item specified: %s' % str(label_item))
+                raise ValueError("Invalid label_item specified: %s" % str(label_item))
             return value
+
     return LabelledModelChoiceField
 
 
@@ -171,7 +189,9 @@ def _get_rel_model(model, parameter_name):
         return rel_model
 
 
-def AutocompleteFilterFactory(title, base_parameter_name, viewname='', use_pk_exact=False, label_by=str):
+def AutocompleteFilterFactory(
+    title, base_parameter_name, viewname="", use_pk_exact=False, label_by=str
+):
     """
     An autocomplete widget filter with a customizable title. Use like this:
         AutocompleteFilterFactory('My title', 'field_name')
@@ -196,7 +216,7 @@ def AutocompleteFilterFactory(title, base_parameter_name, viewname='', use_pk_ex
             super_new.field_name = field_names[-1]
             super_new.parameter_name = base_parameter_name
             if len(field_names) <= 1 and super_new.use_pk_exact:
-                super_new.parameter_name += '__{}__exact'.format(super_new.field_pk)
+                super_new.parameter_name += "__{}__exact".format(super_new.field_pk)
             return super_new
 
     class NewFilter(AutocompleteFilter, metaclass=NewMetaFilter):
@@ -209,7 +229,7 @@ def AutocompleteFilterFactory(title, base_parameter_name, viewname='', use_pk_ex
             self.title = title
 
         def get_autocomplete_url(self, request, model_admin):
-            if viewname == '':
+            if viewname == "":
                 return super().get_autocomplete_url(request, model_admin)
             else:
                 return reverse(viewname)

--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -232,6 +232,7 @@ def AutocompleteFilterFactory(
             if viewname == "":
                 return super().get_autocomplete_url(request, model_admin)
             else:
-                return reverse(viewname)
+                # Pass the current GET parameters to the view. This allows to make co-dependent filters.
+                return reverse(viewname) + "?" + request.GET.urlencode()
 
     return NewFilter


### PR DESCRIPTION
This PR allows for autocomplete filters to receive the GET params from the parent URL so that autocomplete filters can work with other filters.

Example:
Given a User list, If you add an autocomplete filter for "State", you can add another autocomplete filter for "City" that only shows cities for the previously selected State.