### PR TITLE
Add AutocompleteFilterMultiple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ venv.bak/
 
 # PyCharm
 .idea
+
+# Visual Studio Code
+.vscode


### PR DESCRIPTION
Fix #17 

Add AutocompleteFilterMultiple class to support filtering by multiple related items, using `__in` lookup by default. `AutocompleteSelectMultiple` widget is used for rendering.