### PR TITLE
Fix duplicate results if lookup spawns duplicates

### DIFF
--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -1,7 +1,6 @@
 from django.contrib.admin.widgets import AutocompleteSelect as Base
 from django import forms
 from django.contrib import admin
-from django.contrib.admin.utils import lookup_spawns_duplicates
 from django.db.models.fields.related import ForeignObjectRel
 from django.db.models.constants import LOOKUP_SEP  # this is '__'
 from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor, ManyToManyDescriptor
@@ -66,7 +65,7 @@ class AutocompleteFilter(admin.SimpleListFilter):
             required=False,
         )
 
-        self.may_have_duplicates = lookup_spawns_duplicates(model_admin.model._meta, self.parameter_name)
+        self.may_have_duplicates = admin.util.lookup_spawns_duplicates(model_admin.model._meta, self.parameter_name)
         self._add_media(model_admin, widget)
 
         attrs = self.widget_attrs.copy()

--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -1,6 +1,7 @@
 from django.contrib.admin.widgets import AutocompleteSelect as Base
 from django import forms
 from django.contrib import admin
+from django.contrib.admin.utils import lookup_spawns_duplicates
 from django.db.models.fields.related import ForeignObjectRel
 from django.db.models.constants import LOOKUP_SEP  # this is '__'
 from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor, ManyToManyDescriptor
@@ -65,6 +66,7 @@ class AutocompleteFilter(admin.SimpleListFilter):
             required=False,
         )
 
+        self.may_have_duplicates = lookup_spawns_duplicates(model_admin.model._meta, self.parameter_name)
         self._add_media(model_admin, widget)
 
         attrs = self.widget_attrs.copy()
@@ -124,6 +126,8 @@ class AutocompleteFilter(admin.SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value():
+            if self.may_have_duplicates:
+                queryset = queryset.distinct()
             return queryset.filter(**{self.parameter_name: self.value()})
         else:
             return queryset


### PR DESCRIPTION
Django admin already checks most list filter if they may cause duplicates, and it uses `queryset.distinct()` in that case. However, for filters which are callable--AutocompleteFilter for example--that check is skipped. The logic is that the callable filter ought to know already if distinct() is appropriate or not. 

This PR allows filtering on many-to-many relationship where duplicate results could appear:
```python
class MyModelAdmin(ModelAdmin):
    list_filter = (
        # If there are multiple Things related to MyModel through RelatedModel,
        # then duplicates would appear unless queryset.distinct() is set.
        AutocompleteFilterFactory("things", "related_model__thing"),
    )
```

<details><summary>Relevant portions of django/contrib/admin/views/main.py</summary>

```python
class ChangeList:
    def get_filters(self, request):
        lookup_params = self.get_filters_params()
        may_have_duplicates = False
        has_active_filters = False

        ...

        filter_specs = []
        for list_filter in self.list_filter:
            lookup_params_count = len(lookup_params)
            if callable(list_filter):
                # This is simply a custom list filter class.
                spec = list_filter(request, lookup_params, self.model, self.model_admin)
            else:
                ...

                spec = field_list_filter_class(
                    field,
                    request,
                    lookup_params,
                    self.model,
                    self.model_admin,
                    field_path=field_path,
                )
                # field_list_filter_class removes any lookup_params it
                # processes. If that happened, check if duplicates should be
                # removed.
                if lookup_params_count > len(lookup_params):
                    may_have_duplicates |= lookup_spawns_duplicates(
                        self.lookup_opts,
                        field_path,
                    )

        ...

        # At this point, all the parameters used by the various ListFilters
        # have been removed from lookup_params, which now only contains other
        # parameters passed via the query string. We now loop through the
        # remaining parameters both to ensure that all the parameters are valid
        # fields and to determine if at least one of them spawns duplicates. If
        # the lookup parameters aren't real fields, then bail out.
        try:
            for key, value in lookup_params.items():
                lookup_params[key] = prepare_lookup_value(key, value)
                may_have_duplicates |= lookup_spawns_duplicates(self.lookup_opts, key)
            return (
                filter_specs,
                bool(filter_specs),
                lookup_params,
                may_have_duplicates,
                has_active_filters,
            )
        except FieldDoesNotExist as e:
            raise IncorrectLookupParameters(e) from e

    def get_queryset(self, request, exclude_parameters=None):
        # First, we collect all the declared list filters.
        (
            self.filter_specs,
            self.has_filters,
            remaining_lookup_params,
            filters_may_have_duplicates,
            self.has_active_filters,
        ) = self.get_filters(request)
        # Then, we let every list filter modify the queryset to its liking.
        qs = self.root_queryset
        for filter_spec in self.filter_specs:
            if (
                exclude_parameters is None
                or filter_spec.expected_parameters() != exclude_parameters
            ):
                new_qs = filter_spec.queryset(request, qs)
                if new_qs is not None:
                    qs = new_qs

        ...

        # Remove duplicates from results, if necessary
        if filters_may_have_duplicates | search_may_have_duplicates:
            return qs.distinct()
        else:
            return qs
```
</details>

GitHub: [django/contrib/admin/views/main.py](https://github.com/django/django/blob/bc1bfe12b613334bd625aeb36fd44af96d186c10/django/contrib/admin/views/main.py) 